### PR TITLE
Prompt for git name/email during installation

### DIFF
--- a/git/.config/git/config
+++ b/git/.config/git/config
@@ -1,7 +1,4 @@
 [core]
 	excludesFile = ~/.config/git/ignore
-[user]
-	name = Christopher Kapic
-	email = christopherkapic@gmail.com
 [push]
 	autoSetupRemote = true

--- a/install/macos.sh
+++ b/install/macos.sh
@@ -115,6 +115,21 @@ elif $stowed_zsh && [ -f "$HOME/.zshrc" ]; then
   echo "~/.zshrc already exists, skipping template copy"
 fi
 
+# =============================================================================
+# Git user configuration
+# =============================================================================
+echo ""
+echo "--- Git User Configuration ---"
+read -rp "Enter your Git name (or press Enter to skip): " GIT_NAME
+if [ -n "$GIT_NAME" ]; then
+  read -rp "Enter your Git email (or press Enter to skip): " GIT_EMAIL
+  git config --file "$HOME/.gitconfig" user.name "$GIT_NAME"
+  [ -n "$GIT_EMAIL" ] && git config --file "$HOME/.gitconfig" user.email "$GIT_EMAIL"
+  echo "Git user configured."
+else
+  echo "Skipping Git user configuration."
+fi
+
 if ! [ -d "$HOME/.powerlevel10k" ]; then
   git clone --depth=1 https://github.com/romkatv/powerlevel10k.git $HOME/.powerlevel10k
 fi

--- a/install/ubuntu-desktop-24.04.sh
+++ b/install/ubuntu-desktop-24.04.sh
@@ -128,6 +128,21 @@ elif $stowed_zsh && [ -f "$HOME/.zshrc" ]; then
 fi
 
 # =============================================================================
+# Git user configuration
+# =============================================================================
+echo ""
+echo "--- Git User Configuration ---"
+read -rp "Enter your Git name (or press Enter to skip): " GIT_NAME
+if [ -n "$GIT_NAME" ]; then
+  read -rp "Enter your Git email (or press Enter to skip): " GIT_EMAIL
+  git config --file "$HOME/.gitconfig" user.name "$GIT_NAME"
+  [ -n "$GIT_EMAIL" ] && git config --file "$HOME/.gitconfig" user.email "$GIT_EMAIL"
+  echo "Git user configured."
+else
+  echo "Skipping Git user configuration."
+fi
+
+# =============================================================================
 # Step 4: Install powerlevel10k
 # =============================================================================
 if ! [ -d "$HOME/.powerlevel10k" ]; then

--- a/install/ubuntu-server-24.04.sh
+++ b/install/ubuntu-server-24.04.sh
@@ -223,6 +223,22 @@ if ! [ -f "$USER_HOME/.zshrc" ]; then
   chown "$NEW_USER:$NEW_USER" "$USER_HOME/.zshrc"
 fi
 
+# =============================================================================
+# Git user configuration
+# =============================================================================
+echo ""
+echo "--- Git User Configuration ---"
+read -rp "Enter the Git name for '$NEW_USER' (or press Enter to skip): " GIT_NAME
+if [ -n "$GIT_NAME" ]; then
+  read -rp "Enter the Git email for '$NEW_USER' (or press Enter to skip): " GIT_EMAIL
+  git config --file "$USER_HOME/.gitconfig" user.name "$GIT_NAME"
+  [ -n "$GIT_EMAIL" ] && git config --file "$USER_HOME/.gitconfig" user.email "$GIT_EMAIL"
+  chown "$NEW_USER:$NEW_USER" "$USER_HOME/.gitconfig"
+  echo "Git user configured for '$NEW_USER'."
+else
+  echo "Skipping Git user configuration."
+fi
+
 # Install powerlevel10k
 if ! [ -d "$USER_HOME/.powerlevel10k" ]; then
   echo "Installing powerlevel10k..."


### PR DESCRIPTION
## Summary
- Remove hardcoded name/email from `git/.config/git/config`
- All three install scripts now prompt for Git name and email after stowing dotfiles
- User can press Enter to skip; values are written to `~/.gitconfig` (separate from the stowed file)

## Test plan
- [ ] Run `install/macos.sh` and verify the Git name/email prompt appears
- [ ] Verify skipping leaves no user config set
- [ ] Verify entering values writes correctly to `~/.gitconfig`